### PR TITLE
adding POC for issue generation

### DIFF
--- a/provdebug/MarkdownFmt.py
+++ b/provdebug/MarkdownFmt.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from .DebugTrace import DebugTrace
+from .DebugRecord import DebugRecord
+
+class MarkdownFmt:
+    
+    def metadata_str(self, metadata: Dict[str, str]) -> str:
+        header = "# Debugging Trace"
+        os_str = f' * {metadata["os"]}'
+        python_ver_str = f'* {metadata["python-version"]}'
+        return "\n".join([header, os_str, python_ver_str])
+
+    def trace_str(self, debug_trace: DebugTrace) -> str:
+        records = debug_trace._debug_records
+        trace = [self._record_str(i, record) for i, record in enumerate(records)]
+        return "\n".join(trace)
+
+    def _record_str(self, record_index: int, record: DebugRecord) -> str:
+        # adding 1 to record_index to account for 0-based indexing
+        header = f"## Step {record_index + 1}"
+        action_str = f"**Debug action**: {record._userChoice}"
+        program_state_str = f"**Program state**:\n```\n{record._programInfo}\n```"
+        record_strs = [header, action_str, program_state_str]
+        if record._userAnnotation is not None:
+            annotation_str = f"**Annotation**: {record._userAnnotation}"
+            record_strs.append(annotation_str)
+        return "\n".join(record_strs)

--- a/provdebug/__init__.py
+++ b/provdebug/__init__.py
@@ -5,4 +5,5 @@ from .ProvBrowser import Browser
 from .DebugRecord import DebugRecord
 from .DebugTrace import DebugTrace
 from .Serializer import Serializer
+from .MarkdownFmt import MarkdownFmt
 from .ProvReplayer import Replayer

--- a/provdebug/pvdebug.py
+++ b/provdebug/pvdebug.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 from argparse import RawDescriptionHelpFormatter
 from .DebugRecord import DebugRecord
 from .Serializer import Serializer
+from .MarkdownFmt import MarkdownFmt
 import provdebug as prov
 import readline
 import json
@@ -48,6 +49,7 @@ def run():
         Otherwise, the interactive controls are as follows:
             - n or next: step forward in trace
             - b or back: step backward in trace
+            - i or issue: print a prettified version of the entire trace as markdown-formatted output
             - q or quit: quit the replayer
         ''')
         
@@ -113,6 +115,13 @@ def run():
                 else:
                     print("You are at the beginning of the trace.")
                     debugTrace.current_record().prettyPrint(frame_length)
+                continue
+            elif userFlag == "i" or userFlag == "issue":
+                fmt = MarkdownFmt()
+                metadata = fmt.metadata_str(debugTrace._debug_metadata)
+                records = fmt.trace_str(debugTrace)
+                print(metadata)
+                print(records)
                 continue
             elif userFlag == "q" or userFlag == "quit":
                 break
@@ -208,8 +217,6 @@ def run():
             if userActions:
                 filename = input("Enter a name for the recorded debugging trace (.replay): ")
                 Serializer.save_records(userActions, filename)
-                for record in userActions:
-                    record.prettyPrint()
                 print(f"Your debugging trace has been saved in your current working directory as {filename}.replay")
             break
         elif userFlag == "r" or userFlag == "record":


### PR DESCRIPTION
Tested with the following `.replay`file
```json
{
   "metadata":{
      "os":"macOS-11.2.2-x86_64-i386-64bit",
      "python-version":"3.8.2"
   },
   "records":[
      {
         "userAction":"n",
         "programInfo":"1.1. rsf <- 0",
         "userAnnotation":null
      },
      {
         "userAction":"n",
         "programInfo":"1.3. for (i in 1:10) {\n\trsf = rsf + 1\n\tprint(rsf)\n}",
         "userAnnotation":"this is a loop, fam"
      },
      {
         "userAction":"n",
         "programInfo":"1.0. test.R",
         "userAnnotation":null
      },
      {
         "userAction":"s",
         "programInfo":"1.0. test.R",
         "userAnnotation":null
      },
      {
         "userAction":"s",
         "programInfo":"1.1. rsf <- 0",
         "userAnnotation":null
      },
      {
         "userAction":"s",
         "programInfo":"1.3. for (i in 1:10) {\n\trsf = rsf + 1\n\tprint(rsf)\n}",
         "userAnnotation":null
      }
   ]
}
```