### PR TITLE
Add friendlier prompts to annotation option and for unrecognized commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,5 +116,6 @@ dmypy.json
 # R stuff
 .Rhistory
 
-# testing
+# .DS_Store
+.DS_Store
 /test/.DS_Store

--- a/provdebug/pvdebug.py
+++ b/provdebug/pvdebug.py
@@ -56,7 +56,6 @@ def run():
     parser = ArgumentParser(description="provdb starts a provenance-based time traveling debugging interface.",
     formatter_class=RawDescriptionHelpFormatter,
     epilog=helpText)
-    #Uncomment the following to debug
     '''
     #TO DEBUG
     parser.add_argument('--interactive', action='store_true', default=True)
@@ -125,6 +124,8 @@ def run():
                 continue
             elif userFlag == "q" or userFlag == "quit":
                 break
+            else:
+                print(f"'{userFlag}' is an unrecognized command.")
         return
 
     # record of user actions
@@ -247,7 +248,7 @@ def run():
                 latestRecord.setAnnotation(annotation)
                 print("Your annotation has been recorded. Resuming trace...")
         else:
-            print(f"\'{userFlag}\' is an unrecognized command.")
+            print(f"'{userFlag}' is an unrecognized command.")
 
 
         print(browser.getCurrentNodeInfo())

--- a/provdebug/pvdebug.py
+++ b/provdebug/pvdebug.py
@@ -242,9 +242,12 @@ def run():
                 print("Annotate the following:")
                 latestRecord = userActions[-1]
                 latestRecord.printProgramFrame()
+                print("Press ENTER to save. Save without an annotation to resume debugging.")
                 annotation = input("Annotation: ")
                 latestRecord.setAnnotation(annotation)
                 print("Your annotation has been recorded. Resuming trace...")
+        else:
+            print(f"\'{userFlag}\' is an unrecognized command.")
 
 
         print(browser.getCurrentNodeInfo())


### PR DESCRIPTION
Addressing the "cancel"/"I changed my mind about annotating this trace because I'm not annotating what I thought I would be annotating" situation.